### PR TITLE
make logbook python3 compatible

### DIFF
--- a/widget.py
+++ b/widget.py
@@ -345,7 +345,7 @@ class LogbookWidget(QtWidgets.QWidget):
     @property
     def _record_items(self):
         """ all available record items """
-        for row in xrange(self.records_list.count()):
+        for row in range(self.records_list.count()):
             yield self.records_list.item(row)
 
     def add_record(self, log_record):


### PR DESCRIPTION
`xrange()`  was deprecated in Python 3, this PR resolves this issue